### PR TITLE
fixed crash when deleting the topmost pet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,12 @@ fn remove_pet_at_index(pet_list_state: &mut ListState) -> Result<(), Error> {
         let mut parsed: Vec<Pet> = serde_json::from_str(&db_content)?;
         parsed.remove(selected);
         fs::write(DB_PATH, &serde_json::to_vec(&parsed)?)?;
-        pet_list_state.select(Some(selected - 1));
+        let amount_pets = read_db().expect("can fetch pet list").len();
+        if selected > 0 {
+            pet_list_state.select(Some(selected - 1));
+        } else {
+            pet_list_state.select(Some(0));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
So i'm new to rust and thought building my own cli application would be great to learn.
Your example is really cool, thanks for making it available!

However, after hearing so much about rust's "if it compiles, it's gonna work how you expect it to" i was kinda surprised to see this crash the moment i pressed "d". 
edit: turns out it is "working as expected" i guess :) just not as i expected

Thought i'd put the fix out there. it was a simple matter of copying the if/else from one of the movement actions down to the deleting action, so it doesn't try to select the -1 pet in the list.